### PR TITLE
hid.requestDevice returns an array.

### DIFF
--- a/packages/elgato-stream-deck-web/src/index.ts
+++ b/packages/elgato-stream-deck-web/src/index.ts
@@ -20,6 +20,11 @@ export async function requestStreamDeck(options?: OpenStreamDeckOptions): Promis
 			]
 		})
 		.then(async (browserDevice: any) => {
+			// requestDevice returns an array because a physical device might
+			// have multiple HID interfaces.  The StreamDeck only has one:
+			if (browserDevice.length > 0) {
+				browserDevice = browserDevice[0];
+			}
 			const model = DEVICE_MODELS.find(m => m.productId === browserDevice.productId)
 			if (!model) {
 				throw new Error('Stream Deck is of unexpected type.')


### PR DESCRIPTION
The multiple HIDDevice objects returned by requestDevice represent
multiple HID interfaces on the same physical device.  The StreamDeck
only has one interface, so we can always pick that one.