### PR TITLE
Broaden usb detection to any Elgato device.

### DIFF
--- a/packages/node/examples/device-detection.js
+++ b/packages/node/examples/device-detection.js
@@ -38,6 +38,10 @@ refresh()
 
 usbDetect.startMonitoring()
 
-usbDetect.on('add:4057:96', function () {
+usbDetect.on('add:4057', function () {
+	refresh()
+})
+usbDetect.on('remove:4057', function (device) {
+	console.log(`${JSON.stringify(device)} was removed`)
 	refresh()
 })


### PR DESCRIPTION
Broaden USB detection to any Elgato device (not some specific device).
Add notification of device removal.

Signed-off-by: Christoph Willing <chris.willing@linux.com>