### PR TITLE
docs: fix broken links in Node and TCP README.md files

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -92,7 +92,7 @@ export function getStreamDeckInfo(path: string): Promise<StreamDeckDeviceInfo | 
 export function openStreamDeck(devicePath: string, userOptions?: OpenStreamDeckOptionsNode): Promise<StreamDeck>
 ```
 
-The StreamDeck type can be found [here](/packages/core/src/models/types.ts#L15)
+The `StreamDeck` type can be found [here](/packages/core/src/types.ts#L48).
 
 ## Example
 
@@ -127,7 +127,7 @@ await myStreamDeck.fillKeyColor(4, 255, 0, 0)
 console.log('Successfully wrote a red square to key 4.')
 ```
 
-Some more complex demos can be found in the [examples](examples/) folder.
+Some more complex demos can be found in the [examples](/packages/node/examples/) folder.
 
 ## Contributing
 

--- a/packages/tcp/README.md
+++ b/packages/tcp/README.md
@@ -61,7 +61,7 @@ The root methods exposed by the library are as follows. For more information it 
 // TODO
 ```
 
-The StreamDeck type can be found [here](/packages/core/src/models/types.ts#L15)
+The `StreamDeck` type can be found [here](/packages/core/src/types.ts#L48).
 
 ## Example
 
@@ -69,7 +69,7 @@ The StreamDeck type can be found [here](/packages/core/src/models/types.ts#L15)
 // TODO
 ```
 
-Some more complex demos can be found in the [examples](examples/) folder.
+Some more complex demos can be found in the [examples](/packages/tcp/examples/) folder.
 
 ## Contributing
 


### PR DESCRIPTION
The relative links in these README.md files for the Node and TCP packages currently do not work when viewed from the npm registry because they relatively point to the GitHub repository:
- https://www.npmjs.com/package/@elgato-stream-deck/node
- https://www.npmjs.com/package/@elgato-stream-deck/tcp

This change makes the links absolute so they work both in GitHub and in the public npm registry.

Update links to types.ts which moved from
/packages/core/src/models/types.ts to /packages/core/src/types.ts in 37479d8a14.